### PR TITLE
Feature/deprecate cache activated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Run tests
@@ -17,10 +17,10 @@ jobs:
       - name: Removes mocks from tests
         run: cat cover.out.tmp | grep -v "_mock.go" > cover.out
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.49
           args: --skip-files .*_test.go
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2

--- a/decision.go
+++ b/decision.go
@@ -272,21 +272,17 @@ func GetDecision(
 		}
 
 		// 3.1 If allocation is newly computed and not only 1 variation,
-		// or if campaign activation not saved and should be
 		// tag this vg alloc to be saved
-		alreadyActivated := ok && existingAssignment.Activated
-		if triggerHit && !alreadyActivated || isNew {
+		if isNew {
 			newVGAssignments[vg.ID] = &VisitorCache{
 				VariationID: vid,
 				Activated:   triggerHit,
 			}
 		}
 
-		// 3.1 If anonymous allocation is newly computed and not only 1 variation,
-		// or if campaign activation not saved and should be
+		// 3.2 If anonymous allocation is newly computed and not only 1 variation,
 		// tag this vg alloc to be saved
-		alreadyActivatedAnonymous := okAnonymous && existingAssignmentAnonymous.Activated
-		if enableReconciliation && (triggerHit && !alreadyActivatedAnonymous || isNewAnonymous) {
+		if enableReconciliation && isNewAnonymous {
 			newVGAssignmentsAnonymous[vg.ID] = &VisitorCache{
 				VariationID: vid,
 				Activated:   triggerHit,

--- a/decision_utils.go
+++ b/decision_utils.go
@@ -67,9 +67,9 @@ func getPreviousABVGIds(variationGroups []*VariationGroup, existingVar map[strin
 		if vg.Campaign.Type != "ab" {
 			continue
 		}
-		existingVariations, ok := existingVar[vg.ID]
+		_, alreadyAssigned := existingVar[vg.ID]
 		_, added := alreadyAdded[vg.ID]
-		if ok && existingVariations.Activated && !added {
+		if alreadyAssigned && !added {
 			previousVisVGsAB = append(previousVisVGsAB, vg.ID)
 			alreadyAdded[vg.ID] = true
 		}

--- a/decision_utils_test.go
+++ b/decision_utils_test.go
@@ -116,7 +116,7 @@ func TestGetPreviousABVGIds(t *testing.T) {
 	}
 
 	previousVGIds := getPreviousABVGIds(vgs, existingAssignments)
-	assert.EqualValues(t, []string{"testId1", "testId4"}, previousVGIds)
+	assert.EqualValues(t, []string{"testId1", "testId3", "testId4"}, previousVGIds)
 }
 
 func TestGetCampaignsVG(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -28,7 +28,8 @@ type VariationGroup struct {
 // VisitorCache represents a visitor variation group cache item for a variation group
 type VisitorCache struct {
 	VariationID string
-	Activated   bool
+	// Deprecated: not used anymore
+	Activated bool
 }
 
 // VisitorAssignments represents a visitor assignment for a variation group


### PR DESCRIPTION
Change single assignment behavior to use campaign assignments instead of activation to exclude other AB test from being returned to the response